### PR TITLE
SKYR-2383 Refactor error codes

### DIFF
--- a/algolia/algolia_client.go
+++ b/algolia/algolia_client.go
@@ -12,6 +12,15 @@ import (
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
 )
 
+const (
+	ECode050101 = e.Code0501 + "01"
+	ECode050102 = e.Code0501 + "02"
+	ECode050103 = e.Code0501 + "03"
+	ECode050104 = e.Code0501 + "04"
+	ECode050105 = e.Code0501 + "05"
+	ECode050106 = e.Code0501 + "06"
+)
+
 // Algolia handler for pushing index updates to Algolia
 type Algolia struct {
 	Client        *search.Client
@@ -35,7 +44,7 @@ func NewAlgolia(config *model.AlgoliaConfig) (alg *Algolia, err error) {
 	}
 
 	if config.NumGoRoutines > MaxGoroutines {
-		return nil, e.New(e.Code050F, "04",
+		return nil, e.N(ECode050101,
 			fmt.Sprintf("Number go routines '%d' exceeds allowed max: %d",
 				config.NumGoRoutines, MaxGoroutines))
 	} else if config.NumGoRoutines <= 0 {
@@ -55,7 +64,7 @@ func NewAlgolia(config *model.AlgoliaConfig) (alg *Algolia, err error) {
 func (alg *Algolia) Push(item interface{}) (err error) {
 	_, err = alg.Index.SaveObject(item)
 	if err != nil {
-		return e.Wrap(err, e.Code0501, "01")
+		return e.W(err, ECode050102)
 	}
 
 	return nil
@@ -65,7 +74,7 @@ func (alg *Algolia) Push(item interface{}) (err error) {
 func (alg *Algolia) Delete(objectID string) (err error) {
 	_, err = alg.Index.DeleteObject(objectID)
 	if err != nil {
-		return e.Wrap(err, e.Code0502, "01")
+		return e.W(err, ECode050103)
 	}
 
 	return nil
@@ -76,7 +85,7 @@ func (alg *Algolia) Delete(objectID string) (err error) {
 func (alg *Algolia) DeleteBy(opt ...interface{}) (res search.UpdateTaskRes, err error) {
 	res, err = alg.Index.DeleteBy(opt...)
 	if err != nil {
-		return res, e.Wrap(err, e.Code050I, "01")
+		return res, e.W(err, ECode050104)
 	}
 
 	return res, nil
@@ -102,7 +111,7 @@ func (alg *Algolia) SyncItem(db *sql.Connection, item *model.AlgoliaSync) (err e
 		// TODO: save error to algolia_sync_error_text or something similar
 		if err2 := sqlmodel.AlgoliaSyncSetStatus(db, item.ID,
 			model.AlgoliaSyncStatusFailed, &item.ItemHash, item.Item); err2 != nil {
-			return e.Wrap(err, e.Code0505, "01")
+			return e.W(err, ECode050105)
 		}
 
 		// Since saved the status/failure, return nil
@@ -113,7 +122,7 @@ func (alg *Algolia) SyncItem(db *sql.Connection, item *model.AlgoliaSync) (err e
 	if err := sqlmodel.AlgoliaSyncSetStatus(db, item.ID,
 		model.AlgoliaSyncStatusComplete, &item.ItemHash, item.Item); err != nil {
 
-		return e.Wrap(err, e.Code0505, "02")
+		return e.W(err, ECode050106)
 	}
 
 	return nil

--- a/algolia/sqlmodel/algolia_sync.go
+++ b/algolia/sqlmodel/algolia_sync.go
@@ -13,6 +13,19 @@ import (
 const (
 	AlgoliaSyncTableName = "algolia_sync"
 	AlgoliaDefaultSortBy = "algolia_sync_id"
+
+	ECode050301 = e.Code0503 + "01"
+	ECode050302 = e.Code0503 + "02"
+	ECode050303 = e.Code0503 + "03"
+	ECode050304 = e.Code0503 + "04"
+	ECode050305 = e.Code0503 + "05"
+	ECode050306 = e.Code0503 + "06"
+	ECode050307 = e.Code0503 + "07"
+	ECode050308 = e.Code0503 + "08"
+	ECode050309 = e.Code0503 + "09"
+	ECode05030A = e.Code0503 + "0A"
+	ECode05030B = e.Code0503 + "0B"
+	ECode05030C = e.Code0503 + "0C"
 )
 
 // AlgoliaSyncGetParam model
@@ -53,7 +66,7 @@ func AlgoliaSyncUpsert(db *sql.Connection, input *model.AlgoliaSync) (id int, er
 
 	id, err = db.ExecInsertReturningID(ib)
 	if err != nil {
-		return 0, e.Wrap(err, e.Code0504, "01")
+		return 0, e.W(err, ECode050301)
 	}
 
 	return id, nil
@@ -77,7 +90,7 @@ func AlgoliaSyncSetStatus(db *sql.Connection, id int, status string,
 	}
 
 	if err := db.ExecUpdate(ub); err != nil {
-		return e.Wrap(err, e.Code0507, "01")
+		return e.W(err, ECode050302)
 	}
 
 	return nil
@@ -95,7 +108,7 @@ func AlgoliaSyncForDeleteUpdate(db *sql.Connection, id int, delete bool) (err er
 	}
 
 	if err := db.ExecUpdate(ub); err != nil {
-		return e.Wrap(err, e.Code050C, "01")
+		return e.W(err, ECode050303)
 	}
 
 	return nil
@@ -149,13 +162,13 @@ func AlgoliaSyncGet(db *sql.Connection,
 
 	stmt, bindList, err := sb.ToSql()
 	if err != nil {
-		return nil, 0, e.Wrap(err, e.Code0503, "01")
+		return nil, 0, e.W(err, ECode050304)
 	}
 
 	if p.FlagCount {
 		row := db.QueryRow(strings.Replace(stmt, "{fields}", "count(*)", 1), bindList...)
 		if err := row.Scan(&count); err != nil {
-			return nil, 0, e.Wrap(err, e.Code0503, "02",
+			return nil, 0, e.W(err, ECode050305,
 				fmt.Sprintf("AlgoliaSyncGet.2 | stmt: %s, bindList: %+v",
 					stmt, bindList))
 		}
@@ -177,7 +190,7 @@ func AlgoliaSyncGet(db *sql.Connection,
 	stmt = strings.Replace(stmt, "{fields}", fields, 1)
 	rows, err := db.Query(stmt, bindList...)
 	if err != nil {
-		return nil, 0, e.Wrap(err, e.Code0503, "03")
+		return nil, 0, e.W(err, ECode050306)
 	}
 	defer rows.Close()
 
@@ -186,12 +199,12 @@ func AlgoliaSyncGet(db *sql.Connection,
 		if err := rows.Scan(&as.ID, &as.AlgoliaIndex, &as.AlgoliaObjectID, &as.ItemID, &as.Item,
 			&as.ItemHash, &as.Status, &as.ForDelete, &as.ItemType,
 			&as.CreatedOn, &as.UpdatedOn); err != nil {
-			return nil, 0, e.Wrap(err, e.Code0503, "04")
+			return nil, 0, e.W(err, ECode050307)
 		}
 
 		if p.DataHandler != nil {
 			if err := p.DataHandler(as); err != nil {
-				return nil, 0, e.Wrap(err, e.Code0503, "05")
+				return nil, 0, e.W(err, ECode050308)
 			}
 		} else {
 			asList = append(asList, as)
@@ -225,11 +238,11 @@ func AlgoliaSyncGetByItemIDAndType(db *sql.Connection, itemID int,
 
 	asList, _, err := AlgoliaSyncGet(db, p)
 	if err != nil {
-		return nil, e.Wrap(err, e.Code0506, "01")
+		return nil, e.W(err, ECode050309)
 	}
 
 	if len(asList) == 0 {
-		return nil, e.Wrap(err, e.Code0506, "02")
+		return nil, e.W(err, ECode05030A)
 	}
 
 	return asList[0], nil
@@ -253,14 +266,14 @@ func AlgoliaSyncGetItemIDs(db *sql.Connection, limit, offset int, status []strin
 	stmt = strings.Replace(stmt, "{fields}", fields, 1)
 	rows, err := db.Query(stmt, bindList...)
 	if err != nil {
-		return nil, 0, e.Wrap(err, e.Code050E, "01")
+		return nil, 0, e.W(err, ECode05030B)
 	}
 	defer rows.Close()
 
 	for rows.Next() {
 		var id int
 		if err := rows.Scan(&id); err != nil {
-			return nil, 0, e.Wrap(err, e.Code050E, "02")
+			return nil, 0, e.W(err, ECode05030C)
 		}
 
 		idList = append(idList, id)

--- a/arc/arcimedes_user.go
+++ b/arc/arcimedes_user.go
@@ -7,6 +7,17 @@ import (
 	"github.com/Skyrin/go-lib/e"
 )
 
+const (
+	ECode040201 = e.Code0402 + "01"
+	ECode040202 = e.Code0402 + "02"
+	ECode040203 = e.Code0402 + "03"
+	ECode040204 = e.Code0402 + "04"
+	ECode040205 = e.Code0402 + "05"
+	ECode040206 = e.Code0402 + "06"
+	ECode040207 = e.Code0402 + "07"
+	ECode040208 = e.Code0402 + "08"
+)
+
 // RegisterArcimedesUser attempts to create the arcimedes user in arc. If the
 // user already exists in arc, will fetch the arc user id (by the passed
 // username) and then make the call to update it. This should only be called
@@ -38,7 +49,7 @@ func (c *Client) RegisterArcimedesUser(ui *ArcUser, retry bool) (au *ArcUser, er
 
 	ca, err := c.getClientAuth()
 	if err != nil {
-		return nil, e.Wrap(err, e.Code040C, "01")
+		return nil, e.W(err, ECode040201)
 	}
 	res, err := c.sendSingleRequestItem(
 		c.deployment.getManageArcimedesServiceURL(),
@@ -57,22 +68,22 @@ func (c *Client) RegisterArcimedesUser(ui *ArcUser, retry bool) (au *ArcUser, er
 			// First now fetch that user
 			au, err = c.ArcimedesUserGetByUsername(ui.Username)
 			if err != nil {
-				return nil, e.Wrap(err, e.Code040C, "02")
+				return nil, e.W(err, ECode040202)
 			}
 
 			// Try to upsert with the id now
 			ui.ArcUserID = au.ID
 			au, err = c.RegisterArcimedesUser(ui, false)
 			if err != nil {
-				return nil, e.Wrap(err, e.Code040C, "03")
+				return nil, e.W(err, ECode040203)
 			}
 		} else {
-			return nil, e.Wrap(err, e.Code040C, "04")
+			return nil, e.W(err, ECode040204)
 		}
 	} else {
 		au = &ArcUser{}
 		if err := json.Unmarshal(res.Data, au); err != nil {
-			return nil, e.Wrap(err, e.Code040C, "05")
+			return nil, e.W(err, ECode040205)
 		}
 	}
 
@@ -96,19 +107,19 @@ func (c *Client) ArcimedesUserGetByUsername(username string) (au *ArcUser, err e
 
 	ca, err := c.getClientAuth()
 	if err != nil {
-		return nil, e.Wrap(err, e.Code040D, "01")
+		return nil, e.W(err, ECode040206)
 	}
 	res, err := c.sendSingleRequestItem(
 		c.deployment.getManageArcimedesServiceURL(),
 		ri,
 		ca)
 	if err != nil {
-		return nil, e.Wrap(err, e.Code040D, "02")
+		return nil, e.W(err, ECode040207)
 	}
 
 	auList := []*ArcUser{}
 	if err := json.Unmarshal(res.Data, &auList); err != nil {
-		return nil, e.Wrap(err, e.Code040D, "03")
+		return nil, e.W(err, ECode040208)
 	}
 
 	if len(auList) != 1 {

--- a/arc/cart_customer.go
+++ b/arc/cart_customer.go
@@ -7,6 +7,17 @@ import (
 	"github.com/Skyrin/go-lib/e"
 )
 
+const (
+	ECode040301 = e.Code0403 + "01"
+	ECode040302 = e.Code0403 + "02"
+	ECode040303 = e.Code0403 + "03"
+	ECode040304 = e.Code0403 + "04"
+	ECode040305 = e.Code0403 + "05"
+	ECode040306 = e.Code0403 + "06"
+	ECode040307 = e.Code0403 + "07"
+	ECode040308 = e.Code0403 + "08"
+)
+
 // RegisterCartCustomer attempts to create the cart customer in arc. If the
 // customer already exists in arc, will fetch the arc user id (by the passed
 // username) and then make the call to update it. This should only be called
@@ -41,7 +52,7 @@ func (c *Client) RegisterCartCustomer(storeCode string,
 
 	ca, err := c.getClientAuth()
 	if err != nil {
-		return nil, e.Wrap(err, e.Code040E, "01")
+		return nil, e.W(err, ECode040301)
 	}
 	res, err := c.sendSingleRequestItem(
 		c.deployment.getManageCartServiceURL(storeCode),
@@ -60,22 +71,22 @@ func (c *Client) RegisterCartCustomer(storeCode string,
 			// First now fetch that user
 			cust, err = c.CartGetCustomerByUsername(storeCode, ci.Username)
 			if err != nil {
-				return nil, e.Wrap(err, e.Code040E, "02")
+				return nil, e.W(err, ECode040302)
 			}
 
 			// Try to upsert with the id now
 			ci.ArcUserID = cust.ID
 			cust, err = c.RegisterCartCustomer(storeCode, ci, false)
 			if err != nil {
-				return nil, e.Wrap(err, e.Code040E, "02")
+				return nil, e.W(err, ECode040303)
 			}
 		} else {
-			return nil, e.Wrap(err, e.Code040E, "04")
+			return nil, e.W(err, ECode040304)
 		}
 	} else {
 		cust = &ArcUser{}
 		if err := json.Unmarshal(res.Data, cust); err != nil {
-			return nil, e.Wrap(err, e.Code040E, "05")
+			return nil, e.W(err, ECode040305)
 		}
 	}
 
@@ -99,19 +110,19 @@ func (c *Client) CartGetCustomerByUsername(storeCode, username string) (cust *Ar
 
 	ca, err := c.getClientAuth()
 	if err != nil {
-		return nil, e.Wrap(err, e.Code040F, "01")
+		return nil, e.W(err, ECode040306)
 	}
 	res, err := c.sendSingleRequestItem(
 		c.deployment.getManageCartServiceURL(storeCode),
 		ri,
 		ca)
 	if err != nil {
-		return nil, e.Wrap(err, e.Code040F, "02")
+		return nil, e.W(err, ECode040307)
 	}
 
 	custList := []*ArcUser{}
 	if err := json.Unmarshal(res.Data, &custList); err != nil {
-		return nil, e.Wrap(err, e.Code040F, "03")
+		return nil, e.W(err, ECode040308)
 	}
 
 	if len(custList) != 1 {

--- a/arc/core_user.go
+++ b/arc/core_user.go
@@ -7,6 +7,17 @@ import (
 	"github.com/Skyrin/go-lib/e"
 )
 
+const (
+	ECode040401 = e.Code0404 + "01"
+	ECode040402 = e.Code0404 + "02"
+	ECode040403 = e.Code0404 + "03"
+	ECode040404 = e.Code0404 + "04"
+	ECode040405 = e.Code0404 + "05"
+	ECode040406 = e.Code0404 + "06"
+	ECode040407 = e.Code0404 + "07"
+	ECode040408 = e.Code0404 + "08"
+)
+
 // RegisterCoreUser attempts to create the core user in arc. If the
 // user already exists in arc, will fetch the arc user id (by the passed
 // username) and then make the call to update it. This should only be called
@@ -39,7 +50,7 @@ func (c *Client) RegisterCoreUser(ui *ArcUser, retry bool) (au *ArcUser, err err
 
 	ca, err := c.getClientAuth()
 	if err != nil {
-		return nil, e.Wrap(err, e.Code040G, "01")
+		return nil, e.W(err, ECode040401)
 	}
 
 	res, err := c.sendSingleRequestItem(
@@ -60,22 +71,22 @@ func (c *Client) RegisterCoreUser(ui *ArcUser, retry bool) (au *ArcUser, err err
 			// First now fetch that user
 			au, err = c.CoreUserGetByUsername(ui.Username)
 			if err != nil {
-				return nil, e.Wrap(err, e.Code040G, "02")
+				return nil, e.W(err, ECode040402)
 			}
 
 			// Try to upsert with the id now
 			ui.ArcUserID = au.ID
 			au, err = c.RegisterCoreUser(ui, false)
 			if err != nil {
-				return nil, e.Wrap(err, e.Code040G, "03")
+				return nil, e.W(err, ECode040403)
 			}
 		} else {
-			return nil, e.Wrap(err, e.Code040G, "04")
+			return nil, e.W(err, ECode040404)
 		}
 	} else {
 		au = &ArcUser{}
 		if err := json.Unmarshal(res.Data, au); err != nil {
-			return nil, e.Wrap(err, e.Code040G, "05")
+			return nil, e.W(err, ECode040405)
 		}
 	}
 
@@ -99,19 +110,19 @@ func (c *Client) CoreUserGetByUsername(username string) (au *ArcUser, err error)
 
 	ca, err := c.getClientAuth()
 	if err != nil {
-		return nil, e.Wrap(err, e.Code040H, "01")
+		return nil, e.W(err, ECode040406)
 	}
 	res, err := c.sendSingleRequestItem(
 		c.deployment.getManageCoreServiceURL(),
 		ri,
 		ca)
 	if err != nil {
-		return nil, e.Wrap(err, e.Code040H, "02")
+		return nil, e.W(err, ECode040407)
 	}
 
 	auList := []*ArcUser{}
 	if err := json.Unmarshal(res.Data, &auList); err != nil {
-		return nil, e.Wrap(err, e.Code040H, "03")
+		return nil, e.W(err, ECode040408)
 	}
 
 	if len(auList) != 1 {

--- a/arc/deployment.go
+++ b/arc/deployment.go
@@ -11,6 +11,12 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const (
+	ECode040701 = e.Code0407 + "01"
+	ECode040702 = e.Code0407 + "02"
+	ECode040703 = e.Code0407 + "03"
+)
+
 type Deployment struct {
 	DB        *sql.Connection
 	Model     *model.Deployment
@@ -38,7 +44,7 @@ func (d *Deployment) UpdateGrant(g *Grant) (err error) {
 		RefreshToken:       &g.RefreshToken,
 		RefreshTokenExpiry: &g.RefreshTokenExpiry,
 	}); err != nil {
-		return e.Wrap(err, e.Code040I, "01")
+		return e.W(err, ECode040701)
 	}
 
 	return nil
@@ -48,12 +54,12 @@ func (d *Deployment) UpdateGrant(g *Grant) (err error) {
 func NewDeployment(db *sql.Connection, cp *sql.ConnParam, deploymentCode string) (d *Deployment, err error) {
 	md, err := sqlmodel.DeploymentGetByCode(db, deploymentCode)
 	if err != nil {
-		return nil, e.Wrap(err, e.Code040J, "01")
+		return nil, e.W(err, ECode040702)
 	}
 
 	dn, err := NewDeploymentNotify(cp)
 	if err != nil {
-		return nil, e.Wrap(err, e.Code040J, "02")
+		return nil, e.W(err, ECode040703)
 	}
 
 	dn.Notify = func(deploymentCode string) {

--- a/arc/error_codes.go
+++ b/arc/error_codes.go
@@ -1,7 +1,0 @@
-package arc
-
-const (
-	E01F1A8_AuthorizationFailed = "E01F1A8" // Not logged in error
-	E01FWA8_InvalidGrant        = "E01FWA8" // Invalid grant error
-	E01FAAP_InvalidGrantLogin   = "E01FAAP" // Invalid user for oauth2.Grant.login
-)

--- a/arc/grant.go
+++ b/arc/grant.go
@@ -11,6 +11,18 @@ import (
 	"github.com/Skyrin/go-lib/sql"
 )
 
+const (
+	ECode040901 = e.Code0409 + "01"
+	ECode040902 = e.Code0409 + "02"
+	ECode040903 = e.Code0409 + "03"
+	ECode040904 = e.Code0409 + "04"
+	ECode040905 = e.Code0409 + "05"
+	ECode040906 = e.Code0409 + "06"
+	ECode040907 = e.Code0409 + "07"
+	ECode040908 = e.Code0409 + "08"
+	ECode040909 = e.Code0409 + "09"
+)
+
 // Grant
 type Grant struct {
 	Token              string `json:"accessToken"`
@@ -47,18 +59,18 @@ func grantClientCredentials(c *Client, id, secret string) (g *Grant, err error) 
 
 	res, err := c.sendSingleRequestItem(c.deployment.getManageCoreServiceURL(), ri, nil)
 	if err != nil {
-		return nil, e.Wrap(err, e.Code040N, "01")
+		return nil, e.W(err, ECode040901)
 	}
 
 	if !res.Success {
 
-		return nil, e.Wrap(err, e.Code040N, "02",
+		return nil, e.W(err, ECode040902,
 			fmt.Sprintf("[%s]%s", res.ErrorCode, res.Message))
 	}
 
 	g = &Grant{}
 	if err := json.Unmarshal(res.Data, g); err != nil {
-		return nil, e.Wrap(err, e.Code040N, "03")
+		return nil, e.W(err, ECode040903)
 	}
 
 	return g, nil
@@ -86,14 +98,14 @@ func (g *Grant) refresh(c *Client, clientID, secret string,
 
 	res, err := c.sendSingleRequestItem(c.deployment.getManageCoreServiceURL(), ri, nil)
 	if err != nil {
-		return false, e.Wrap(err, e.Code040O, "01")
+		return false, e.W(err, ECode040904)
 	}
 
 	var tmpGrant *Grant
 	if res.Data != nil {
 		tmpGrant = &Grant{}
 		if err := json.Unmarshal(res.Data, tmpGrant); err != nil {
-			return false, e.Wrap(err, e.Code040O, "02")
+			return false, e.W(err, ECode040905)
 		}
 	}
 
@@ -112,17 +124,17 @@ func (g *Grant) refresh(c *Client, clientID, secret string,
 func GrantRefresh(db *sql.Connection, c *Client, credentialID int, token string) (g *Grant, err error) {
 	credential, err := sqlmodel.CredentialGetByID(c.deployment.DB, credentialID)
 	if err != nil {
-		return nil, e.Wrap(err, e.Code040P, "01")
+		return nil, e.W(err, ECode040906)
 	}
 
 	dg, err := sqlmodel.DeploymentGrantGetByToken(db, token)
 	if err != nil {
-		return nil, e.New(e.Code040P, "01", e.MsgUnauthorized)
+		return nil, e.N(ECode040907, e.MsgUnauthorized)
 	}
 
 	g = SQLDeploymentGrantToGrant(dg)
 	if _, err := g.refresh(c, credential.ClientID, credential.ClientSecret, true); err != nil {
-		return nil, e.Wrap(err, e.Code040P, "02")
+		return nil, e.W(err, ECode040908)
 	}
 
 	// Update the database record
@@ -133,7 +145,7 @@ func GrantRefresh(db *sql.Connection, c *Client, credentialID int, token string)
 			RefreshToken:       &g.RefreshToken,
 			RefreshTokenExpiry: &g.RefreshTokenExpiry,
 		}); err != nil {
-		return nil, e.Wrap(err, e.Code040P, "03")
+		return nil, e.W(err, ECode040909)
 	}
 
 	return g, nil

--- a/arc/response.go
+++ b/arc/response.go
@@ -7,6 +7,10 @@ import (
 	"github.com/Skyrin/go-lib/e"
 )
 
+const (
+	ECode040A01 = e.Code040A + "01"
+)
+
 // ResponseList represents the notification service response
 type ResponseList struct {
 	ID        int        `json:"id"`
@@ -31,7 +35,7 @@ type Response struct {
 // responseErrors returns errors found in the response if any.  Can add other checks for errors
 func (nrl *ResponseList) responseErrors() error {
 	if !nrl.Success {
-		return e.New(e.Code040Q, "01", fmt.Sprintf("%+v", nrl))
+		return e.N(ECode040A01, fmt.Sprintf("%+v", nrl))
 	}
 
 	return nil

--- a/arc/response_error.go
+++ b/arc/response_error.go
@@ -1,5 +1,10 @@
 package arc
 
+// These constants refer to some possible error codes that come from an
+// arc deployment API call (not within this library)
 const (
-	E01FAAE_UserAlreadyExists = "E01FAAE"
+	E01FAAE_UserAlreadyExists   = "E01FAAE"
+	E01F1A8_AuthorizationFailed = "E01F1A8" // Not logged in error
+	E01FWA8_InvalidGrant        = "E01FWA8" // Invalid grant error
+	E01FAAP_InvalidGrantLogin   = "E01FAAP" // Invalid user for oauth2.Grant.login
 )

--- a/arc/sqlmodel/credential.go
+++ b/arc/sqlmodel/credential.go
@@ -12,6 +12,13 @@ import (
 const (
 	CredentialTableName     = "arc_credential"
 	CredentialDefaultSortBy = "arc_credential_id"
+
+	ECode040B01 = e.Code040B + "01"
+	ECode040B02 = e.Code040B + "02"
+	ECode040B03 = e.Code040B + "03"
+	ECode040B04 = e.Code040B + "04"
+	ECode040B05 = e.Code040B + "05"
+	ECode040B06 = e.Code040B + "06"
 )
 
 // UserGetParam model
@@ -49,13 +56,13 @@ func CredentialGet(db *sql.Connection,
 
 	stmt, bindList, err := sb.ToSql()
 	if err != nil {
-		return nil, 0, e.Wrap(err, e.Code040R, "01")
+		return nil, 0, e.W(err, ECode040B01)
 	}
 
 	if p.FlagCount {
 		row := db.QueryRow(strings.Replace(stmt, "{fields}", "count(*)", 1), bindList...)
 		if err := row.Scan(&count); err != nil {
-			return nil, 0, e.Wrap(err, e.Code040R, "02",
+			return nil, 0, e.W(err, ECode040B02,
 				fmt.Sprintf("CredentialGet.2 | stmt: %s, bindList: %+v",
 					stmt, bindList))
 		}
@@ -76,7 +83,7 @@ func CredentialGet(db *sql.Connection,
 
 	rows, err := db.Query(stmt, bindList...)
 	if err != nil {
-		return nil, 0, e.Wrap(err, e.Code040R, "03")
+		return nil, 0, e.W(err, ECode040B03)
 	}
 	defer rows.Close()
 
@@ -84,7 +91,7 @@ func CredentialGet(db *sql.Connection,
 		c := &model.Credential{}
 		if err := rows.Scan(&c.ID, &c.DeploymentID, &c.Name,
 			&c.ClientID, &c.ClientSecret); err != nil {
-			return nil, 0, e.Wrap(err, e.Code040R, "04")
+			return nil, 0, e.W(err, ECode040B04)
 		}
 
 		cList = append(cList, c)
@@ -101,11 +108,11 @@ func CredentialGetByID(db *sql.Connection, id int) (c *model.Credential, err err
 	})
 
 	if err != nil {
-		return nil, e.Wrap(err, e.Code040S, "01")
+		return nil, e.W(err, ECode040B05)
 	}
 
 	if len(cList) != 1 {
-		return nil, e.New(e.Code040S, "01", e.MsgCredentialDoesNotExist)
+		return nil, e.N(ECode040B06, e.MsgCredentialDoesNotExist)
 	}
 
 	return cList[0], nil

--- a/arc/sqlmodel/data.go
+++ b/arc/sqlmodel/data.go
@@ -12,6 +12,18 @@ import (
 
 const (
 	DataTableName = "arc_data"
+
+	ECode040C01 = e.Code040C + "01"
+	ECode040C02 = e.Code040C + "02"
+	ECode040C03 = e.Code040C + "03"
+	ECode040C04 = e.Code040C + "04"
+	ECode040C05 = e.Code040C + "05"
+	ECode040C06 = e.Code040C + "06"
+	ECode040C07 = e.Code040C + "07"
+	ECode040C08 = e.Code040C + "08"
+	ECode040C09 = e.Code040C + "09"
+	ECode040C0A = e.Code040C + "0A"
+	ECode040C0B = e.Code040C + "0B"
 )
 
 // DataGetParam model
@@ -41,7 +53,7 @@ func DataSetStatus(db *sql.Connection, s model.DataStatus, d *model.Data) (err e
 
 	err = db.ExecUpdate(ub)
 	if err != nil {
-		return e.Wrap(err, e.Code0414, "02")
+		return e.W(err, ECode040C01)
 	}
 
 	return nil
@@ -76,7 +88,7 @@ func DataUpsert(db *sql.Connection, d *model.Data) (err error) {
 
 	err = db.ExecInsert(ib)
 	if err != nil {
-		return e.Wrap(err, e.Code0411, "01")
+		return e.W(err, ECode040C02)
 	}
 
 	return nil
@@ -119,13 +131,13 @@ func DataGet(db *sql.Connection,
 
 	stmt, bindList, err := sb.ToSql()
 	if err != nil {
-		return nil, 0, e.Wrap(err, e.Code0412, "01")
+		return nil, 0, e.W(err, ECode040C03)
 	}
 
 	if p.FlagCount {
 		row := db.QueryRow(strings.Replace(stmt, "{fields}", "count(*)", 1), bindList...)
 		if err := row.Scan(&count); err != nil {
-			return nil, 0, e.Wrap(err, e.Code0412, "02",
+			return nil, 0, e.W(err, ECode040C04,
 				fmt.Sprintf("stmt: %s, bindList: %+v", stmt, bindList))
 		}
 	}
@@ -155,7 +167,7 @@ func DataGet(db *sql.Connection,
 
 	rows, err := db.Query(stmt, bindList...)
 	if err != nil {
-		return nil, 0, e.Wrap(err, e.Code0412, "03")
+		return nil, 0, e.W(err, ECode040C05)
 	}
 	defer rows.Close()
 
@@ -164,12 +176,12 @@ func DataGet(db *sql.Connection,
 		if err := rows.Scan(&d.AppCode, &d.AppCoreID, &d.Type, &d.ObjectID,
 			&d.Object, &d.Hash, &d.Deleted, &d.Status,
 			&d.CreatedOn, &d.UpdatedOn); err != nil {
-			return nil, 0, e.Wrap(err, e.Code0412, "04")
+			return nil, 0, e.W(err, ECode040C06)
 		}
 
 		if p.Handle != nil {
 			if err := p.Handle(d); err != nil {
-				return nil, 0, e.Wrap(err, e.Code0412, "05")
+				return nil, 0, e.W(err, ECode040C07)
 			}
 		} else {
 			dList = append(dList, d)
@@ -192,11 +204,11 @@ func DataGetByObjectID(db *sql.Connection, appCode model.AppCode,
 	})
 
 	if err != nil {
-		return nil, e.Wrap(err, e.Code0413, "01")
+		return nil, e.W(err, ECode040C08)
 	}
 
 	if len(dList) != 1 {
-		return nil, e.New(e.Code0413, "02", e.MsgDataDoesNotExist)
+		return nil, e.N(ECode040C09, e.MsgDataDoesNotExist)
 	}
 
 	return dList[0], nil
@@ -211,7 +223,7 @@ func DataSetStatusProcessing(db *sql.Connection) (err error) {
 
 	err = db.ExecUpdate(ub)
 	if err != nil {
-		return e.Wrap(err, e.Code0414, "02")
+		return e.W(err, ECode040C0A)
 	}
 
 	return nil
@@ -226,7 +238,7 @@ func DataSetStatusProcessed(db *sql.Connection) (err error) {
 
 	err = db.ExecUpdate(ub)
 	if err != nil {
-		return e.Wrap(err, e.Code0414, "02")
+		return e.W(err, ECode040C0B)
 	}
 
 	return nil

--- a/arc/sqlmodel/deployment.go
+++ b/arc/sqlmodel/deployment.go
@@ -12,6 +12,14 @@ import (
 const (
 	DeploymentTableName     = "arc_deployment"
 	DeploymentDefaultSortBy = "arc_deployment_id"
+
+	ECode040D01 = e.Code040D + "01"
+	ECode040D02 = e.Code040D + "02"
+	ECode040D03 = e.Code040D + "03"
+	ECode040D04 = e.Code040D + "04"
+	ECode040D05 = e.Code040D + "05"
+	ECode040D06 = e.Code040D + "06"
+	ECode040D07 = e.Code040D + "07"
 )
 
 // UserGetParam model
@@ -61,7 +69,7 @@ func DeploymentUpdate(db *sql.Connection, id int, dup *DeploymentUpdateParam) (e
 
 	err = db.ExecUpdate(ub)
 	if err != nil {
-		return e.Wrap(err, e.Code040T, "01")
+		return e.W(err, ECode040D01)
 	}
 
 	return nil
@@ -95,13 +103,13 @@ func DeploymentGet(db *sql.Connection,
 
 	stmt, bindList, err := sb.ToSql()
 	if err != nil {
-		return nil, 0, e.Wrap(err, e.Code040U, "01")
+		return nil, 0, e.W(err, ECode040D02)
 	}
 
 	if p.FlagCount {
 		row := db.QueryRow(strings.Replace(stmt, "{fields}", "count(*)", 1), bindList...)
 		if err := row.Scan(&count); err != nil {
-			return nil, 0, e.Wrap(err, e.Code040U, "02",
+			return nil, 0, e.W(err, ECode040D03,
 				fmt.Sprintf("stmt: %s, bindList: %+v", stmt, bindList))
 		}
 	}
@@ -121,7 +129,7 @@ func DeploymentGet(db *sql.Connection,
 
 	rows, err := db.Query(stmt, bindList...)
 	if err != nil {
-		return nil, 0, e.Wrap(err, e.Code040U, "03")
+		return nil, 0, e.W(err, ECode040D04)
 	}
 	defer rows.Close()
 
@@ -133,7 +141,7 @@ func DeploymentGet(db *sql.Connection,
 			&d.Token, &d.TokenExpiry,
 			&d.RefreshToken, &d.RefreshTokenExpiry,
 			&d.LogEventCode, &d.LogPublishKey); err != nil {
-			return nil, 0, e.Wrap(err, e.Code040U, "04")
+			return nil, 0, e.W(err, ECode040D05)
 		}
 
 		dList = append(dList, d)
@@ -150,11 +158,11 @@ func DeploymentGetByCode(db *sql.Connection, code string) (d *model.Deployment, 
 	})
 
 	if err != nil {
-		return nil, e.Wrap(err, e.Code040V, "01")
+		return nil, e.W(err, ECode040D06)
 	}
 
 	if len(dList) != 1 {
-		return nil, e.New(e.Code040V, "02", e.MsgDeploymentDoesNotExist)
+		return nil, e.N(ECode040D07, e.MsgDeploymentDoesNotExist)
 	}
 
 	return dList[0], nil

--- a/arc/sqlmodel/deployment_grant.go
+++ b/arc/sqlmodel/deployment_grant.go
@@ -13,6 +13,16 @@ import (
 const (
 	DeploymentGrantTableName     = "arc_deployment_grant"
 	DeploymentGrantDefaultSortBy = "arc_deployment_grant_id"
+
+	ECode040Z01 = e.Code040Z + "01"
+	ECode040Z02 = e.Code040Z + "02"
+	ECode040Z03 = e.Code040Z + "03"
+	ECode040Z04 = e.Code040Z + "04"
+	ECode040Z05 = e.Code040Z + "05"
+	ECode040Z06 = e.Code040Z + "06"
+	ECode040Z07 = e.Code040Z + "07"
+	ECode040Z08 = e.Code040Z + "08"
+	ECode040Z09 = e.Code040Z + "09"
 )
 
 // DeploymentGrantGetParam get params
@@ -70,7 +80,7 @@ func DeploymentGrantInsert(db *sql.Connection, ip *DeploymentGrantInsertParam) (
 
 	id, err = db.ExecInsertReturningID(ib)
 	if err != nil {
-		return 0, e.Wrap(err, e.Code040W, "01")
+		return 0, e.W(err, ECode040Z02)
 	}
 
 	return id, nil
@@ -105,7 +115,7 @@ func DeploymentGrantUpdate(db *sql.Connection, id int, up *DeploymentGrantUpdate
 
 	err = db.ExecUpdate(ub)
 	if err != nil {
-		return e.Wrap(err, e.Code040X, "01")
+		return e.W(err, ECode040Z03)
 	}
 
 	return nil
@@ -141,13 +151,13 @@ func DeploymentGrantGet(db *sql.Connection,
 
 	stmt, bindList, err := sb.ToSql()
 	if err != nil {
-		return nil, 0, e.Wrap(err, e.Code040Y, "01")
+		return nil, 0, e.W(err, ECode040Z04)
 	}
 
 	if p.FlagCount {
 		row := db.QueryRow(strings.Replace(stmt, "{fields}", "count(*)", 1), bindList...)
 		if err := row.Scan(&count); err != nil {
-			return nil, 0, e.Wrap(err, e.Code040Y, "02",
+			return nil, 0, e.W(err, ECode040Z05,
 				fmt.Sprintf("stmt: %s", stmt))
 		}
 	}
@@ -167,7 +177,7 @@ func DeploymentGrantGet(db *sql.Connection,
 
 	rows, err := db.Query(stmt, bindList...)
 	if err != nil {
-		return nil, 0, e.Wrap(err, e.Code040Y, "03")
+		return nil, 0, e.W(err, ECode040Z06)
 	}
 	defer rows.Close()
 
@@ -177,7 +187,7 @@ func DeploymentGrantGet(db *sql.Connection,
 			&dg.CredentialID,
 			&dg.Token, &dg.TokenExpiry,
 			&dg.RefreshToken, &dg.RefreshTokenExpiry); err != nil {
-			return nil, 0, e.Wrap(err, e.Code040Y, "04")
+			return nil, 0, e.W(err, ECode040Z07)
 		}
 
 		dgList = append(dgList, dg)
@@ -194,11 +204,11 @@ func DeploymentGrantGetByToken(db *sql.Connection, token string) (dg *model.Depl
 	})
 
 	if err != nil {
-		return nil, e.Wrap(err, e.Code040Z, "01")
+		return nil, e.W(err, ECode040Z08)
 	}
 
 	if len(dgList) != 1 {
-		return nil, e.New(e.Code040Z, "01", e.MsgGrantDoesNotExist)
+		return nil, e.N(ECode040Z01, e.MsgGrantDoesNotExist)
 	}
 
 	return dgList[0], nil
@@ -210,7 +220,7 @@ func DeploymentGrantPurgeByToken(db *sql.Connection, token string) (err error) {
 		Where("arc_deployment_grant_token=?", token)
 
 	if err := db.ExecDelete(delB); err != nil {
-		return e.Wrap(err, e.Code0410, "01")
+		return e.W(err, ECode040Z09)
 	}
 
 	return nil

--- a/e/codes.go
+++ b/e/codes.go
@@ -15,56 +15,17 @@ package e
 
 const (
 	// package: migration
-	Code0001 = "0001"
-	Code0002 = "0002"
-	Code0003 = "0003"
-	Code0004 = "0004"
-	Code0005 = "0005"
-	Code0006 = "0006"
-	Code0007 = "0007"
-	Code0008 = "0008"
-
-	// package: migration/sqlmodel
-	Code0101 = "0101"
-	Code0102 = "0102"
-	Code0103 = "0103"
-	Code0104 = "0104"
-	Code0105 = "0105"
+	Code0001 = "0001" // package:migration | migration/migration.go
+	Code0002 = "0002" // package:migration | migration/migration_list.go
+	Code0003 = "0003" // package:migration/sqlmodel | migration/sqlmodel/migration.go
 
 	// package: sql
-	Code0201 = "0201"
-	Code0202 = "0202"
-	Code0203 = "0203"
-	Code0204 = "0204"
-	Code0205 = "0205"
-	Code0206 = "0206"
-	Code0207 = "0207"
-	Code0208 = "0208"
-	Code0209 = "0209"
-	Code020A = "020A"
-	Code020B = "020B"
-	Code020C = "020C"
-	Code020D = "020D"
-	Code020E = "020E"
-	Code020F = "020F"
-	Code020G = "020G"
-	Code020H = "020H"
-	Code020I = "020I"
-	Code020J = "020J"
-	Code020K = "020K"
-	Code020L = "020L"
-	Code020M = "020M"
-	Code020N = "020N"
-	Code020O = "020O"
-	Code020P = "020P"
-	Code020Q = "020Q"
-	Code020R = "020R"
-	Code020S = "020S"
-	Code020T = "020T"
-	Code020U = "020U"
-
-	//package: http
-	// Code0301 = "0301"
+	Code0201 = "0201" // package:sql | sql/count.go
+	Code0202 = "0202" // package:sql | sql/row.go
+	Code0203 = "0203" // package:sql | sql/sql.go
+	Code0204 = "0204" // package:sql | sql/status.go
+	Code0205 = "0205" // package:sql | sql/txn.go
+	Code0206 = "0206" // package:sql | sql/rows.go
 
 	// package: process
 	Code0301 = "0301" // package:process | process/process.go
@@ -72,86 +33,49 @@ const (
 	Code0303 = "0303" // package:sqlmodel | process/internal/sqlmodel/process_run.go
 
 	//package: arc
-	Code0401 = "0401"
-	Code0402 = "0402"
-	Code0403 = "0403"
-	Code0404 = "0404"
-	Code0405 = "0405"
-	Code0406 = "0406"
-	Code0407 = "0407"
-	Code0408 = "0408"
-	Code0409 = "0409"
-	Code040A = "040A"
-	Code040B = "040B"
-	Code040C = "040C"
-	Code040D = "040D"
-	Code040E = "040E"
-	Code040F = "040F"
-	Code040G = "040G"
-	Code040H = "040H"
-	Code040I = "040I"
-	Code040J = "040J"
-	Code040K = "040K"
-	Code040L = "040L"
-	Code040M = "040M"
-	Code040N = "040N"
-	Code040O = "040O"
-	Code040P = "040P"
-	Code040Q = "040Q"
-	Code040R = "040R"
-	Code040S = "040S"
-	Code040T = "040T"
-	Code040U = "040U"
-	Code040V = "040V"
-	Code040W = "040W"
-	Code040X = "040X"
-	Code040Y = "040Y"
-	Code040Z = "040Z"
-	Code0410 = "0410"
-	Code0411 = "0411"
-	Code0412 = "0412"
-	Code0413 = "0413"
-	Code0414 = "0414"
-	Code0415 = "0415"
-	Code0416 = "0416"
+	Code0401 = "0401" // package:arc | arc/arc_client.go
+	Code0402 = "0402" // package:arc | arc/arcimedes_user.go
+	Code0403 = "0403" // package:arc | arc/cart_customer.go
+	Code0404 = "0404" // package:arc | arc/core_user.go
+	Code0405 = "0405" // package:arc | arc/deployment_data.go
+	Code0406 = "0406" // package:arc | arc/deployment_notify.go
+	Code0407 = "0407" // package:arc | arc/deployment.go
+	Code0408 = "0408" // package:arc | arc/grant_login.go
+	Code0409 = "0409" // package:arc | arc/grant.go
+	Code040A = "040A" // package:arc | arc/response.go
+	Code040B = "040B" // package:arc/sqlmodel | arc/sqlmodel/credential.go
+	Code040C = "040C" // package:arc/sqlmodel | arc/sqlmodel/data.go
+	Code040D = "040D" // package:arc/sqlmodel | arc/sqlmodel/deployment.go
+	// Code040E = "040E"
+	// Code040F = "040F"
+	// Code040G = "040G"
+	// Code040H = "040H"
+	// Code040I = "040I"
+	// Code040J = "040J"
+	// Code040K = "040K"
+	// Code040L = "040L"
+	// Code040M = "040M"
+	// Code040N = "040N"
+	// Code040O = "040O"
+	// Code040P = "040P"
+	// Code040Q = "040Q"
+	// Code040R = "040R"
+	// Code040S = "040S"
+	// Code040T = "040T"
+	// Code040U = "040U"
+	// Code040V = "040V"
+	// Code040W = "040W"
+	// Code040X = "040X"
+	// Code040Y = "040Y"
+	Code040Z = "040Z" // package:arc/sqlmodel | arc/sqlmodel/deployment_grant.go
 
 	//package: algolia
 	Code0501 = "0501"
 	Code0502 = "0502"
 	Code0503 = "0503"
-	Code0504 = "0504"
-	Code0505 = "0505"
-	Code0506 = "0506"
-	Code0507 = "0507"
-	Code0508 = "0508"
-	Code0509 = "0509"
-	Code050A = "050A"
-	Code050B = "050B"
-	Code050C = "050C"
-	Code050D = "050D"
-	Code050E = "050E"
-	Code050F = "050F"
-	Code050G = "050G"
-	Code050H = "050H"
-	Code050I = "050I"
 
 	//package: sync
 	Code0601 = "0601"
 	Code0602 = "0602"
 	Code0603 = "0603"
-	Code0604 = "0604"
-	Code0605 = "0605"
-	Code0606 = "0606"
-	//Code0607 = "0607"
-	//Code0608 = "0608"
-	//Code0609 = "0609"
-	//Code060A = "060A"
-	Code060B = "060B"
-	Code060C = "060C"
-	Code060D = "060D"
-	Code060E = "060E"
-	Code060F = "060F"
-	//Code060G = "060G"
-	Code060H = "060H"
-	Code060I = "060I"
 )

--- a/migration/migration list.go
+++ b/migration/migration list.go
@@ -8,6 +8,15 @@ import (
 	"github.com/Skyrin/go-lib/e"
 )
 
+const (
+	ECode000201 = e.Code0002 + "01"
+	ECode000202 = e.Code0002 + "02"
+	ECode000203 = e.Code0002 + "03"
+	ECode000204 = e.Code0002 + "04"
+	ECode000205 = e.Code0002 + "05"
+	ECode000206 = e.Code0002 + "06"
+)
+
 type File struct {
 	Name    string
 	Version int
@@ -38,7 +47,7 @@ func NewList(code, path string, migrations embed.FS) (l *List) {
 func (f *File) GetVersionFromName() (v int, err error) {
 	sList := strings.Split(f.Name, "_")
 	if len(sList) == 0 {
-		return 0, e.WrapWithMsg(nil, e.Code0001, "01", e.MsgMigrationFileNameInvalid)
+		return 0, e.WWM(nil, ECode000201, e.MsgMigrationFileNameInvalid)
 	}
 
 	if len(sList) == 1 {
@@ -47,11 +56,11 @@ func (f *File) GetVersionFromName() (v int, err error) {
 
 	v, err = strconv.Atoi(sList[0])
 	if err != nil {
-		return 0, e.WrapWithMsg(err, e.Code0001, "02", e.MsgMigrationFileNameInvalid)
+		return 0, e.WWM(err, ECode000202, e.MsgMigrationFileNameInvalid)
 	}
 
 	if v <= 0 {
-		return 0, e.WrapWithMsg(err, e.Code0001, "03", e.MsgMigrationFileNameInvalid)
+		return 0, e.WWM(err, ECode000203, e.MsgMigrationFileNameInvalid)
 	}
 
 	return v, nil
@@ -63,7 +72,7 @@ func (l List) GetLatestMigrationFiles(v int) (fList []*File, err error) {
 
 	dirList, err := l.migrations.ReadDir(l.path)
 	if err != nil {
-		return nil, e.Wrap(err, e.Code0002, "01")
+		return nil, e.W(err, ECode000204)
 	}
 	fList = make([]*File, 0, len(dirList))
 
@@ -83,7 +92,7 @@ func (l List) GetLatestMigrationFiles(v int) (fList []*File, err error) {
 
 		f.Version, err = f.GetVersionFromName()
 		if err != nil {
-			return nil, e.Wrap(err, e.Code0002, "02")
+			return nil, e.W(err, ECode000205)
 		}
 
 		// TODO: ensure incremental versions?
@@ -95,7 +104,7 @@ func (l List) GetLatestMigrationFiles(v int) (fList []*File, err error) {
 		// Should be a file we are looking for
 		f.SQL, err = l.migrations.ReadFile(embededFilePath)
 		if err != nil {
-			return nil, e.Wrap(err, e.Code0002, "03")
+			return nil, e.W(err, ECode000206)
 		}
 
 		fList = append(fList, f)

--- a/migration/migrator.go
+++ b/migration/migrator.go
@@ -39,6 +39,22 @@ const (
 	MIGRATION_TABLE = "skyrin_migration"
 	MIGRATION_PATH  = "db/migrations"
 	MIGRATION_CODE  = "migration"
+
+	ECode000101 = e.Code0001 + "01"
+	ECode000102 = e.Code0001 + "02"
+	ECode000103 = e.Code0001 + "03"
+	ECode000104 = e.Code0001 + "04"
+	ECode000105 = e.Code0001 + "05"
+	ECode000106 = e.Code0001 + "06"
+	ECode000107 = e.Code0001 + "07"
+	ECode000108 = e.Code0001 + "08"
+	ECode000109 = e.Code0001 + "09"
+	ECode00010A = e.Code0001 + "0A"
+	ECode00010B = e.Code0001 + "0B"
+	ECode00010C = e.Code0001 + "0C"
+	ECode00010D = e.Code0001 + "0D"
+	ECode00010E = e.Code0001 + "0E"
+	ECode00010F = e.Code0001 + "0F"
 )
 
 type Migrator struct {
@@ -61,14 +77,14 @@ func NewMigrator(db *sql.Connection) (m *Migrator, err error) {
 	}
 	if err := m.AddMigrationList(ml); err != nil {
 		if !e.ContainsError(err, e.MsgMigrationNotInstalled) {
-			return nil, e.Wrap(err, e.Code0003, "01")
+			return nil, e.W(err, ECode000101)
 		}
 		if err := m.install(ml); err != nil {
-			return nil, e.Wrap(err, e.Code0003, "02")
+			return nil, e.W(err, ECode000102)
 		}
 		// Try to add again now that the migrator is installed
 		if err := m.AddMigrationList(ml); err != nil {
-			return nil, e.Wrap(err, e.Code0003, "03")
+			return nil, e.W(err, ECode000103)
 		}
 	}
 
@@ -84,7 +100,7 @@ func (m *Migrator) AddMigrationList(ml *List) (err error) {
 		// migrations for the specified code yet, then return a place holder
 		// Otherwise, return the error now
 		if !e.ContainsError(err, e.MsgMigrationNone) {
-			return e.Wrap(err, e.Code0004, "01")
+			return e.W(err, ECode000104)
 		}
 
 		// If no migrations exist, then this is a brand new installation
@@ -104,7 +120,7 @@ func (m *Migrator) AddMigrationList(ml *List) (err error) {
 
 	ml.files, err = ml.GetLatestMigrationFiles(mm.Version)
 	if err != nil {
-		return e.Wrap(err, e.Code0004, "02")
+		return e.W(err, ECode000105)
 	}
 
 	m.migrations = append(m.migrations, ml)
@@ -118,16 +134,16 @@ func (m *Migrator) install(ml *List) (err error) {
 
 	files, err := ml.GetLatestMigrationFiles(0)
 	if err != nil {
-		return e.Wrap(err, e.Code0005, "01")
+		return e.W(err, ECode000106)
 	}
 
 	if len(files) == 0 {
-		return e.New(e.Code0005, "02", e.MsgMigrationInstallFailed)
+		return e.N(ECode000107, e.MsgMigrationInstallFailed)
 	}
 
 	// Only run the first migration, the rest will be run via regular upgrade
 	if _, err := m.db.Exec(string(files[0].SQL)); err != nil {
-		return e.Wrap(err, e.Code0005, "03")
+		return e.W(err, ECode000108)
 	}
 
 	return nil
@@ -142,7 +158,7 @@ func (m *Migrator) Upgrade() (err error) {
 			// Check if this file should be run or not
 			id, run, err := m.checkShouldRunFile(ml, f)
 			if err != nil {
-				return e.Wrap(err, e.Code0006, "01")
+				return e.W(err, ECode000109)
 			}
 			if !run {
 				// If it shouldn't run, then skip it
@@ -150,7 +166,7 @@ func (m *Migrator) Upgrade() (err error) {
 			}
 
 			if err := m.processFile(id, ml, f); err != nil {
-				return e.Wrap(err, e.Code0006, "02")
+				return e.W(err, ECode00010A)
 			}
 		}
 	}
@@ -169,7 +185,7 @@ func (m *Migrator) checkShouldRunFile(ml *List, f *File) (id int, shouldRun bool
 	if err != nil {
 		// Return error if it is not e.MsgMigrationCodeVersionDNE
 		if !e.ContainsError(err, e.MsgMigrationCodeVersionDNE) {
-			return 0, false, e.Wrap(err, e.Code0007, "01")
+			return 0, false, e.W(err, ECode00010B)
 		}
 
 		// If we didn't try to process it, then insert it now
@@ -181,7 +197,7 @@ func (m *Migrator) checkShouldRunFile(ml *List, f *File) (id int, shouldRun bool
 			Err:     "",
 		})
 		if err != nil {
-			return 0, false, e.Wrap(err, e.Code0007, "02")
+			return 0, false, e.W(err, ECode00010C)
 		}
 	} else {
 		id = mm.ID
@@ -206,9 +222,9 @@ func (m *Migrator) processFile(id int, ml *List, f *File) (err error) {
 			Status: &status,
 			Err:    &errMsg,
 		}); err2 != nil {
-			return e.Wrap(err, e.Code0008, "01")
+			return e.W(err, ECode00010D)
 		}
-		return e.Wrap(err, e.Code0008, "02")
+		return e.W(err, ECode00010E)
 	}
 
 	status = model.MIGRATION_STATUS_COMPLETE
@@ -217,7 +233,7 @@ func (m *Migrator) processFile(id int, ml *List, f *File) (err error) {
 		Status: &status,
 		Err:    &errMsg,
 	}); err != nil {
-		return e.Wrap(err, e.Code0008, "03")
+		return e.W(err, ECode00010F)
 	}
 
 	log.Info().Msgf("successfully migrated '%s' to version: %v",

--- a/migration/sqlmodel/migration.go
+++ b/migration/sqlmodel/migration.go
@@ -12,6 +12,18 @@ import (
 const (
 	MigrationTableName     = "skyrin_migration"
 	MigrationDefaultSortBy = "skyrin_migration_id"
+
+	ECode000301 = e.Code0003 + "01"
+	ECode000302 = e.Code0003 + "02"
+	ECode000303 = e.Code0003 + "03"
+	ECode000304 = e.Code0003 + "04"
+	ECode000305 = e.Code0003 + "05"
+	ECode000306 = e.Code0003 + "06"
+	ECode000307 = e.Code0003 + "07"
+	ECode000308 = e.Code0003 + "08"
+	ECode000309 = e.Code0003 + "09"
+	ECode00030A = e.Code0003 + "0A"
+	ECode00030B = e.Code0003 + "0B"
 )
 
 // MigrationGetParam get params
@@ -57,7 +69,7 @@ func MigrationInsert(db *sql.Connection, ip *MigrationInsertParam) (id int, err 
 
 	id, err = db.ExecInsertReturningID(ib)
 	if err != nil {
-		return 0, e.Wrap(err, e.Code0101, "01",
+		return 0, e.W(err, ECode000301,
 			fmt.Sprintf("params: %s, %v, %s, SQL redacted, %s",
 				ip.Code, ip.Version, ip.Status, ip.Err))
 	}
@@ -93,7 +105,7 @@ func MigrationUpdate(db *sql.Connection, id int, up *MigrationUpdateParam) (err 
 
 	err = db.ExecUpdate(ub)
 	if err != nil {
-		return e.Wrap(err, e.Code0102, "01",
+		return e.W(err, ECode000302,
 			fmt.Sprintf("params: %d, %v, %v, SQL redacted, %v",
 				id, up.Version, up.Status, up.Err))
 	}
@@ -134,13 +146,13 @@ func MigrationGet(db *sql.Connection,
 
 	stmt, bindList, err := sb.ToSql()
 	if err != nil {
-		return nil, 0, e.Wrap(err, e.Code0103, "01")
+		return nil, 0, e.W(err, ECode000303)
 	}
 
 	if p.FlagCount {
 		row := db.QueryRow(strings.Replace(stmt, "{fields}", "count(*)", 1), bindList...)
 		if err := row.Scan(&count); err != nil {
-			return nil, 0, e.Wrap(err, e.Code0103, "02",
+			return nil, 0, e.W(err, ECode000304,
 				fmt.Sprintf("stmt: %s | bindList: %v", stmt, bindList))
 		}
 	}
@@ -160,7 +172,7 @@ func MigrationGet(db *sql.Connection,
 
 	rows, err := db.Query(stmt, bindList...)
 	if err != nil {
-		return nil, 0, e.Wrap(err, e.Code0103, "03",
+		return nil, 0, e.W(err, ECode000305,
 			fmt.Sprintf("bindList: %v", bindList))
 	}
 	defer rows.Close()
@@ -170,7 +182,7 @@ func MigrationGet(db *sql.Connection,
 		if err := rows.Scan(&m.ID, &m.Code, &m.Version,
 			&m.Status, &m.SQL, &m.Err,
 			&m.CreatedOn, &m.UpdatedOn); err != nil {
-			return nil, 0, e.Wrap(err, e.Code0103, "04",
+			return nil, 0, e.W(err, ECode000306,
 				fmt.Sprintf("stmt: %s | bindList: %v", stmt, bindList))
 		}
 
@@ -191,11 +203,11 @@ func MigrationGetByCodeAndVersion(db *sql.Connection, code string,
 	})
 
 	if err != nil {
-		return nil, e.Wrap(err, e.Code0104, "01")
+		return nil, e.W(err, ECode000307)
 	}
 
 	if len(mList) != 1 {
-		return nil, e.New(e.Code0104, "02", e.MsgMigrationCodeVersionDNE)
+		return nil, e.N(ECode000308, e.MsgMigrationCodeVersionDNE)
 	}
 
 	return mList[0], nil
@@ -211,13 +223,13 @@ func MigrationGetLatest(db *sql.Connection, code string) (m *model.Migration, er
 	if err != nil {
 		// Check for table does not exist error
 		if e.IsPQError(err, e.PQErr42P01) {
-			return nil, e.New(e.Code0105, "01", e.MsgMigrationNotInstalled)
+			return nil, e.N(ECode000309, e.MsgMigrationNotInstalled)
 		}
-		return nil, e.Wrap(err, e.Code0105, "02")
+		return nil, e.W(err, ECode00030A)
 	}
 
 	if len(mList) != 1 {
-		return nil, e.New(e.Code0105, "03", e.MsgMigrationNone)
+		return nil, e.N(ECode00030B, e.MsgMigrationNone)
 	}
 
 	return mList[0], nil

--- a/sql/count.go
+++ b/sql/count.go
@@ -13,6 +13,9 @@ const (
 	FieldPlaceHolder = "<FIELD_PLACE_HOLDER>"
 	// FieldCount TODO: move to more generic location
 	FieldCount = "count(*) AS cnt"
+
+	ECode020101 = e.Code0201 + "01"
+	ECode020102 = e.Code0201 + "02"
 )
 
 // QueryCount gets the count from a select builder query.
@@ -24,13 +27,13 @@ func (c *Connection) QueryCount(sb sq.SelectBuilder) (count int, err error) {
 	// Get the count before pplying an offset
 	stmt, bindParams, err := sb.ToSql()
 	if err != nil {
-		return 0, e.Wrap(err, e.Code020T, "01")
+		return 0, e.W(err, ECode020101)
 	}
 
 	cntStmt := strings.Replace(stmt, FieldPlaceHolder, FieldCount, 1)
 	row := c.QueryRow(cntStmt, bindParams...)
 	if err := row.Scan(&count); err != nil {
-		return 0, e.Wrap(err, e.Code020T, "02",
+		return 0, e.W(err, ECode020102,
 			fmt.Sprintf("bindParams: %+v", bindParams))
 	}
 

--- a/sql/row.go
+++ b/sql/row.go
@@ -7,6 +7,11 @@ import (
 	"github.com/Skyrin/go-lib/e"
 )
 
+const (
+	ECode020201 = e.Code0202 + "01"
+	ECode020202 = e.Code0202 + "02"
+)
+
 // Row a wrapper struct for sql.Row, so error handling can happen
 type Row struct {
 	row   *sql.Row
@@ -16,7 +21,7 @@ type Row struct {
 // Scan wrapper for row's Scan, which returns an extended error instead
 func (r *Row) Scan(dest ...interface{}) error {
 	if err := r.row.Scan(dest...); err != nil {
-		return e.Wrap(err, e.Code020C, "01", fmt.Sprintf("query: %s", r.query))
+		return e.W(err, ECode020201, fmt.Sprintf("query: %s", r.query))
 	}
 
 	return nil
@@ -29,5 +34,5 @@ func (r *Row) Err() error {
 		return nil
 	}
 
-	return e.Wrap(err, e.Code020D, "01", fmt.Sprintf("query: %s", r.query))
+	return e.W(err, ECode020202, fmt.Sprintf("query: %s", r.query))
 }

--- a/sql/rows.go
+++ b/sql/rows.go
@@ -7,6 +7,12 @@ import (
 	"github.com/Skyrin/go-lib/e"
 )
 
+const (
+	ECode020601 = e.Code0206 + "01"
+	ECode020602 = e.Code0206 + "02"
+	ECode020603 = e.Code0206 + "03"
+)
+
 // Rows wrapper struct for sql.Rows, so error handling can happen
 type Rows struct {
 	rows  *sql.Rows
@@ -16,7 +22,7 @@ type Rows struct {
 // Scan wrapper for row's Scan, which returns an extended error instead
 func (r *Rows) Scan(dest ...interface{}) error {
 	if err := r.rows.Scan(dest...); err != nil {
-		return e.Wrap(err, e.Code020E, "01", fmt.Sprintf("query: %s", r.query))
+		return e.W(err, ECode020601, fmt.Sprintf("query: %s", r.query))
 	}
 
 	return nil
@@ -29,13 +35,13 @@ func (r *Rows) Err() error {
 		return nil
 	}
 
-	return e.Wrap(err, e.Code020F, "01", fmt.Sprintf("query: %s", r.query))
+	return e.W(err, ECode020602, fmt.Sprintf("query: %s", r.query))
 }
 
 // Close wrapper for row's Close func - returns extended error instead
 func (r *Rows) Close() error {
 	if err := r.rows.Close(); err != nil {
-		return e.Wrap(err, e.Code020G, "01", fmt.Sprintf("query: %s", r.query))
+		return e.W(err, ECode020603, fmt.Sprintf("query: %s", r.query))
 	}
 
 	return nil

--- a/sql/sql.go
+++ b/sql/sql.go
@@ -16,6 +16,36 @@ import (
 	_ "github.com/lib/pq"
 )
 
+const (
+	ECode020301 = e.Code0203 + "01"
+	ECode020302 = e.Code0203 + "02"
+	ECode020303 = e.Code0203 + "03"
+	ECode020304 = e.Code0203 + "04"
+	ECode020305 = e.Code0203 + "05"
+	ECode020306 = e.Code0203 + "06"
+	ECode020307 = e.Code0203 + "07"
+	ECode020308 = e.Code0203 + "08"
+	ECode020309 = e.Code0203 + "09"
+	ECode02030A = e.Code0203 + "0A"
+	ECode02030B = e.Code0203 + "0B"
+	ECode02030C = e.Code0203 + "0C"
+	ECode02030D = e.Code0203 + "0D"
+	ECode02030E = e.Code0203 + "0E"
+	ECode02030F = e.Code0203 + "0F"
+	ECode02030G = e.Code0203 + "0G"
+	ECode02030H = e.Code0203 + "0H"
+	ECode02030I = e.Code0203 + "0I"
+	ECode02030J = e.Code0203 + "0J"
+	ECode02030K = e.Code0203 + "0K"
+	ECode02030L = e.Code0203 + "0L"
+	ECode02030M = e.Code0203 + "0M"
+	ECode02030N = e.Code0203 + "0N"
+	ECode02030O = e.Code0203 + "0O"
+	ECode02030P = e.Code0203 + "0P"
+	ECode02030Q = e.Code0203 + "0Q"
+	ECode02030R = e.Code0203 + "0R"
+)
+
 // Connection wrapper of the *sql.DB
 // If a transaction is started, it is stored internally in the txn and automatically
 // used when making DB calls until commit/rollback is executed. If during a txn, a
@@ -82,11 +112,11 @@ func GetConnParamFromJSONConfig(configPath string) (cp *ConnParam, err error) {
 
 	b, err := os.ReadFile(configPath)
 	if err != nil {
-		return nil, e.Wrap(err, e.Code020O, "01", err.Error(), configPath)
+		return nil, e.W(err, ECode020301, err.Error(), configPath)
 	}
 
 	if err := json.Unmarshal(b, cp); err != nil {
-		return nil, e.Wrap(err, e.Code020O, "02", err.Error())
+		return nil, e.W(err, ECode020302, err.Error())
 	}
 
 	if cp.SSLMode != "" {
@@ -145,10 +175,10 @@ func NewPostgresConn(cp *ConnParam) (conn *Connection, err error) {
 	//TODO: handle errors better
 	sqlConn, err := sql.Open("postgres", GetConnectionStr(cp))
 	if err != nil {
-		return nil, e.WrapWithMsg(err, e.Code0201, "01", "Failed to connect to DB")
+		return nil, e.WWM(err, ECode020303, "Failed to connect to DB")
 	}
 	if err := sqlConn.Ping(); err != nil {
-		return nil, e.WrapWithMsg(err, e.Code0201, "02", "Failed to ping DB")
+		return nil, e.WWM(err, ECode020304, "Failed to ping DB")
 	}
 
 	return &Connection{DB: sqlConn, Slug: NewSlug(nil)}, nil
@@ -167,11 +197,11 @@ func (c *Connection) Txn() *sql.Tx {
 // If txn is not nil (already in a txn), it will return an error
 func (c *Connection) BeginUseDefaultTxn() (err error) {
 	if c.txn != nil {
-		return e.Wrap(nil, e.Code020N, "01")
+		return e.W(nil, ECode020305)
 	}
 	txn, err := c.DB.Begin()
 	if err != nil {
-		return e.Wrap(err, e.Code020N, "02")
+		return e.W(err, ECode020306)
 	}
 
 	c.txn = &Txn{
@@ -187,7 +217,7 @@ func (c *Connection) BeginUseDefaultTxn() (err error) {
 func (c *Connection) BeginReturnDB() (db *Connection, err error) {
 	txn, err := c.DB.Begin()
 	if err != nil {
-		return nil, e.Wrap(err, e.Code020H, "01")
+		return nil, e.W(err, ECode020307)
 	}
 
 	c.txnIdx = c.txnIdx + 1
@@ -210,11 +240,11 @@ func (c *Connection) BeginReturnDB() (db *Connection, err error) {
 // called within a go routine
 func (c *Connection) Begin() (err error) {
 	if c.txn != nil {
-		return e.WrapWithMsg(nil, e.Code0202, "01", "in a txn")
+		return e.WWM(nil, ECode020308, "in a txn")
 	}
 	txn, err := c.DB.Begin()
 	if err != nil {
-		return e.Wrap(err, e.Code0202, "02")
+		return e.W(err, ECode020309)
 	}
 
 	c.txn = &Txn{
@@ -227,11 +257,11 @@ func (c *Connection) Begin() (err error) {
 // Commit wrapper for sql.Commit. If successfull, will unset the txn object
 func (c *Connection) Commit() (err error) {
 	if c.txn == nil {
-		return e.WrapWithMsg(nil, e.Code0203, "01", "not in a txn")
+		return e.WWM(nil, ECode02030A, "not in a txn")
 	}
 
 	if err = c.txn.Commit(); err != nil {
-		return e.Wrap(err, e.Code0203, "02")
+		return e.W(err, ECode02030B)
 	}
 
 	c.txn = nil
@@ -257,14 +287,14 @@ func (c *Connection) Rollback() {
 		log.Warn().Msg("[Connection.Rollback.1] not in txn")
 		return
 		// TODO: replace with this (Rollback needs to return an error)
-		// return e.Wrap(nil, "Connection.Rollback.1 - not in txn", "")
+		// return e.W(nil, "Connection.Rollback.1 - not in txn", "")
 	}
 
 	if err := c.txn.Rollback(); err != nil {
 		log.Error().Err(err).Msg("[Connection.Rollback.2]")
 		return
 		// TODO: replace with this (Rollback needs to return an error)
-		// return e.Wrap(err, "Connection.Rollback.2", "")
+		// return e.W(err, "Connection.Rollback.2", "")
 	}
 
 	c.txn = nil
@@ -277,7 +307,7 @@ func (c *Connection) Query(query string, args ...interface{}) (rows *Rows, err e
 		if err != nil {
 			// Not logging args because it may contain sensitive information. The
 			// caller can log them if needed
-			return nil, e.Wrap(err, e.Code0204, "01", fmt.Sprintf("query: %s\n", query))
+			return nil, e.W(err, ECode02030C, fmt.Sprintf("query: %s\n", query))
 		}
 		return rows, nil
 	}
@@ -286,7 +316,7 @@ func (c *Connection) Query(query string, args ...interface{}) (rows *Rows, err e
 	if err != nil {
 		// Not logging args because it may contain sensitive information. The
 		// caller can log them if needed
-		return nil, e.Wrap(err, e.Code0204, "02", fmt.Sprintf("query: %s\n", query))
+		return nil, e.W(err, ECode02030D, fmt.Sprintf("query: %s\n", query))
 	}
 
 	return &Rows{
@@ -304,7 +334,7 @@ func (c *Connection) Exec(query string, args ...interface{}) (res sql.Result, er
 	if err != nil {
 		// Not logging args because it may contain sensitive information. The
 		// caller can log them if needed
-		return nil, e.Wrap(err, e.Code0205, "01", fmt.Sprintf("query: %s\n", query))
+		return nil, e.W(err, ECode02030E, fmt.Sprintf("query: %s\n", query))
 	}
 
 	return res, nil
@@ -353,14 +383,14 @@ func (c *Connection) ToSQLAndQuery(sb sq.SelectBuilder) (rows *Rows, err error) 
 	if err != nil {
 		// Not logging args because it may contain sensitive information. The
 		// caller can log them if needed
-		return nil, e.Wrap(err, e.Code0206, "01", fmt.Sprintf("stmt: %s\n", stmt))
+		return nil, e.W(err, ECode02030F, fmt.Sprintf("stmt: %s\n", stmt))
 	}
 
 	sqlRows, err := c.DB.Query(stmt, bindList...)
 	if err != nil {
 		// Not logging args because it may contain sensitive information. The
 		// caller can log them if needed
-		return nil, e.Wrap(err, e.Code0206, "02", fmt.Sprintf("stmt: %s\n", stmt))
+		return nil, e.W(err, ECode02030G, fmt.Sprintf("stmt: %s\n", stmt))
 	}
 
 	return &Rows{
@@ -376,7 +406,7 @@ func (c *Connection) ToSQLAndQueryRow(sb sq.SelectBuilder) (row *Row, err error)
 	if err != nil {
 		// Not logging args because it may contain sensitive information. The
 		// caller can log them if needed
-		return nil, e.Wrap(err, e.Code0207, "01", fmt.Sprintf("stmt: %s\n", stmt))
+		return nil, e.W(err, ECode02030H, fmt.Sprintf("stmt: %s\n", stmt))
 	}
 
 	return c.QueryRow(stmt, bindList...), nil
@@ -388,13 +418,13 @@ func (c *Connection) ExecInsert(ib sq.InsertBuilder) (err error) {
 	if err != nil {
 		// Not logging args because it may contain sensitive information. The
 		// caller can log them if needed
-		return e.Wrap(err, e.Code0208, "01", fmt.Sprintf("stmt: %s\n", stmt))
+		return e.W(err, ECode02030I, fmt.Sprintf("stmt: %s\n", stmt))
 	}
 
 	if _, err := c.Exec(stmt, bindList...); err != nil {
 		// Not logging args because it may contain sensitive information. The
 		// caller can log them if needed
-		return e.Wrap(err, e.Code0208, "02")
+		return e.W(err, ECode02030J)
 	}
 
 	return nil
@@ -406,13 +436,13 @@ func (c *Connection) ExecUpdate(ub sq.UpdateBuilder) (err error) {
 	if err != nil {
 		// Not logging args because it may contain sensitive information. The
 		// caller can log them if needed
-		return e.Wrap(err, e.Code0209, "01", fmt.Sprintf("stmt: %s\n", stmt))
+		return e.W(err, ECode02030K, fmt.Sprintf("stmt: %s\n", stmt))
 	}
 
 	if _, err := c.Exec(stmt, bindList...); err != nil {
 		// Not logging args because it may contain sensitive information. The
 		// caller can log them if needed
-		return e.Wrap(err, e.Code0209, "02")
+		return e.W(err, ECode02030L)
 	}
 
 	return nil
@@ -424,13 +454,13 @@ func (c *Connection) ExecDelete(delB sq.DeleteBuilder) (err error) {
 	if err != nil {
 		// Not logging args because it may contain sensitive information. The
 		// caller can log them if needed
-		return e.Wrap(err, e.Code020A, "01", fmt.Sprintf("stmt: %s\n", stmt))
+		return e.W(err, ECode02030M, fmt.Sprintf("stmt: %s\n", stmt))
 	}
 
 	if _, err := c.Exec(stmt, bindList...); err != nil {
 		// Not logging args because it may contain sensitive information. The
 		// caller can log them if needed
-		return e.Wrap(err, e.Code020A, "02")
+		return e.W(err, ECode02030N)
 	}
 
 	return nil
@@ -442,14 +472,14 @@ func (c *Connection) ExecInsertReturningID(ib sq.InsertBuilder) (id int, err err
 	if err != nil {
 		// Not logging args because it may contain sensitive information. The
 		// caller can log them if needed
-		return 0, e.Wrap(err, e.Code020B, "01", fmt.Sprintf("stmt: %s\n", stmt))
+		return 0, e.W(err, ECode02030O, fmt.Sprintf("stmt: %s\n", stmt))
 	}
 
 	if err := c.QueryRow(stmt, bindList...).Scan(&id); err != nil {
 		// Not logging args because it may contain sensitive information. The
 		// caller can log them if needed
 		// The "query" is logged in Scan, so no need to add here
-		return 0, e.Wrap(err, e.Code020B, "02")
+		return 0, e.W(err, ECode02030P)
 	}
 
 	return id, nil
@@ -462,13 +492,13 @@ func (c *Connection) ExecInsertReturningID(ib sq.InsertBuilder) (id int, err err
 func (c *Connection) ToSQLWFieldAndQuery(sb sq.SelectBuilder, fields string) (rows *Rows, err error) {
 	stmt, bindParams, err := sb.ToSql()
 	if err != nil {
-		return nil, e.Wrap(err, e.Code020U, "01")
+		return nil, e.W(err, ECode02030Q)
 	}
 
 	stmt = strings.Replace(stmt, FieldPlaceHolder, fields, 1)
 	rows, err = c.Query(stmt, bindParams...)
 	if err != nil {
-		return nil, e.Wrap(err, e.Code020U, "02",
+		return nil, e.W(err, ECode02030R,
 			fmt.Sprintf("bindParams: %+v", bindParams))
 	}
 

--- a/sql/status.go
+++ b/sql/status.go
@@ -6,6 +6,19 @@ import (
 	"github.com/Skyrin/go-lib/e"
 )
 
+const (
+	ECode020401 = e.Code0204 + "01"
+	ECode020402 = e.Code0204 + "02"
+	ECode020403 = e.Code0204 + "03"
+	ECode020404 = e.Code0204 + "04"
+	ECode020405 = e.Code0204 + "05"
+	ECode020406 = e.Code0204 + "06"
+	ECode020407 = e.Code0204 + "07"
+	ECode020408 = e.Code0204 + "08"
+	ECode020409 = e.Code0204 + "09"
+	ECode02040A = e.Code0204 + "0A"
+)
+
 // Status defines a status reference for a table/column combination. The table/column/id
 // should be unique (as well as the table/column/code).
 type Status struct {
@@ -27,12 +40,12 @@ func (db *Connection) SetStatusLoad(f func(*Connection) ([]*Status, error)) {
 // statusRefLoad loads all status ref entries into the statusMap
 func (db *Connection) statusRefLoad() (err error) {
 	if db.statusLoader == nil {
-		return e.New(e.Code020P, "01", "No status loader defined")
+		return e.N(ECode020401, "No status loader defined")
 	}
 
 	sList, err := db.statusLoader(db)
 	if err != nil {
-		return e.Wrap(err, e.Code020P, "02")
+		return e.W(err, ECode020402)
 	}
 
 	db.statusMap = make(map[string][]*Status, len(sList))
@@ -54,13 +67,13 @@ func statusGetKey(table, column string) (key string) {
 func (db *Connection) StatusGetByCode(table, column, code string) (s *Status, err error) {
 	if db.statusMap == nil {
 		if err := db.statusRefLoad(); err != nil {
-			return nil, e.Wrap(err, e.Code020Q, "01")
+			return nil, e.W(err, ECode020403)
 		}
 	}
 
 	tmpList, ok := db.statusMap[statusGetKey(table, column)]
 	if !ok {
-		return nil, e.New(e.Code020Q, "02",
+		return nil, e.N(ECode020404,
 			fmt.Sprintf("Invalid status table/column: %s/%s", table, column))
 	}
 
@@ -70,7 +83,7 @@ func (db *Connection) StatusGetByCode(table, column, code string) (s *Status, er
 		}
 	}
 
-	return nil, e.New(e.Code020Q, "03",
+	return nil, e.N(ECode020405,
 		fmt.Sprintf("Status does not exist: table: %s, col: %s, code: %s",
 			table, column, code))
 }
@@ -80,13 +93,13 @@ func (db *Connection) StatusGetByCode(table, column, code string) (s *Status, er
 func (db *Connection) StatusGetByID(table, column string, id int) (s *Status, err error) {
 	if db.statusMap == nil {
 		if err := db.statusRefLoad(); err != nil {
-			return nil, e.Wrap(err, e.Code020R, "01")
+			return nil, e.W(err, ECode020406)
 		}
 	}
 
 	tmpList, ok := db.statusMap[statusGetKey(table, column)]
 	if !ok {
-		return nil, e.New(e.Code020R, "02",
+		return nil, e.N(ECode020407,
 			fmt.Sprintf("Invalid status table/column: %s/%s", table, column))
 	}
 
@@ -96,7 +109,7 @@ func (db *Connection) StatusGetByID(table, column string, id int) (s *Status, er
 		}
 	}
 
-	return nil, e.New(e.Code020R, "03",
+	return nil, e.N(ECode020408,
 		fmt.Sprintf("Status does not exist: table: %s, col: %s, id: %d",
 			table, column, id))
 }
@@ -105,13 +118,13 @@ func (db *Connection) StatusGetByID(table, column string, id int) (s *Status, er
 func (db *Connection) StatusGetListByTblAndCol(table, column string) (sList []*Status, err error) {
 	if db.statusMap == nil {
 		if err := db.statusRefLoad(); err != nil {
-			return nil, e.Wrap(err, e.Code020S, "01")
+			return nil, e.W(err, ECode020409)
 		}
 	}
 
 	tmpList, ok := db.statusMap[statusGetKey(table, column)]
 	if !ok {
-		return nil, e.New(e.Code020S, "02",
+		return nil, e.N(ECode02040A,
 			fmt.Sprintf("Invalid status table/column: %s/%s", table, column))
 	}
 

--- a/sql/txn.go
+++ b/sql/txn.go
@@ -9,6 +9,16 @@ import (
 	_ "github.com/lib/pq"
 )
 
+const (
+	ECode020501 = e.Code0205 + "01"
+	ECode020502 = e.Code0205 + "02"
+	ECode020503 = e.Code0205 + "03"
+	ECode020504 = e.Code0205 + "04"
+	ECode020505 = e.Code0205 + "05"
+	ECode020506 = e.Code0205 + "06"
+	ECode020507 = e.Code0205 + "07"
+)
+
 // Txn wrapper of the *sql.Txn
 type Txn struct {
 	txn *sql.Tx
@@ -28,11 +38,11 @@ func (t *Txn) RollbackIfInTxn() {
 // Rollback attempts to roll back the txn
 func (t *Txn) Rollback() (err error) {
 	if t.txn == nil {
-		return e.Wrap(err, e.Code020I, "01")
+		return e.W(err, ECode020501)
 	}
 
 	if err := t.txn.Rollback(); err != nil {
-		return e.Wrap(err, e.Code020I, "02")
+		return e.W(err, ECode020502)
 	}
 
 	t.txn = nil
@@ -43,11 +53,11 @@ func (t *Txn) Rollback() (err error) {
 // Commit attempts to commit the txn
 func (t *Txn) Commit() (err error) {
 	if t.txn == nil {
-		return e.Wrap(err, e.Code020J, "01")
+		return e.W(err, ECode020503)
 	}
 
 	if err = t.txn.Commit(); err != nil {
-		return e.Wrap(err, e.Code020J, "02")
+		return e.W(err, ECode020504)
 	}
 
 	t.txn = nil
@@ -61,7 +71,7 @@ func (t *Txn) Exec(query string, args ...interface{}) (res sql.Result, err error
 	if err != nil {
 		// Not logging args because it may contain sensitive information. The
 		// caller can log them if needed
-		return nil, e.Wrap(err, e.Code020K, "01", fmt.Sprintf("query: %s\n", query))
+		return nil, e.W(err, ECode020505, fmt.Sprintf("query: %s\n", query))
 	}
 
 	return res, nil
@@ -71,7 +81,7 @@ func (t *Txn) Exec(query string, args ...interface{}) (res sql.Result, err error
 func (t *Txn) Prepare(query string) (stmt *sql.Stmt, err error) {
 	stmt, err = t.txn.Prepare(query)
 	if err != nil {
-		return nil, e.Wrap(err, e.Code020L, "01", query)
+		return nil, e.W(err, ECode020506, query)
 	}
 
 	return stmt, nil
@@ -83,7 +93,7 @@ func (t *Txn) Query(query string, args ...interface{}) (rows *Rows, err error) {
 	if err != nil {
 		// Not logging args because it may contain sensitive information. The
 		// caller can log them if needed
-		return nil, e.Wrap(err, e.Code020M, "01", fmt.Sprintf("query: %s\n", query))
+		return nil, e.W(err, ECode020507, fmt.Sprintf("query: %s\n", query))
 	}
 
 	return &Rows{

--- a/sync/sqlmodel/sync_queue.go
+++ b/sync/sqlmodel/sync_queue.go
@@ -13,6 +13,24 @@ import (
 const (
 	SyncQueueTableName     = "sync_queue"
 	SyncQueueDefaultSortBy = "sync_queue_id"
+
+	ECode060301 = e.Code0603 + "01"
+	ECode060302 = e.Code0603 + "02"
+	ECode060303 = e.Code0603 + "03"
+	ECode060304 = e.Code0603 + "04"
+	ECode060305 = e.Code0603 + "05"
+	ECode060306 = e.Code0603 + "06"
+	ECode060307 = e.Code0603 + "07"
+	ECode060308 = e.Code0603 + "08"
+	ECode060309 = e.Code0603 + "09"
+	ECode06030A = e.Code0603 + "0A"
+	ECode06030B = e.Code0603 + "0B"
+	ECode06030C = e.Code0603 + "0C"
+	ECode06030D = e.Code0603 + "0D"
+	ECode06030E = e.Code0603 + "0E"
+	ECode06030F = e.Code0603 + "0F"
+	ECode06030G = e.Code0603 + "0G"
+	ECode06030H = e.Code0603 + "0H"
 )
 
 // SyncQueueGetParam model
@@ -56,7 +74,7 @@ func Upsert(db *sql.Connection, input *model.SyncQueue) (id int, err error) {
 
 	id, err = db.ExecInsertReturningID(ib)
 	if err != nil {
-		return 0, e.Wrap(err, e.Code0601, "01")
+		return 0, e.W(err, ECode060301)
 	}
 
 	return id, nil
@@ -75,7 +93,7 @@ func SyncQueueSetStatus(db *sql.Connection, id int, status string) (err error) {
 	}
 
 	if err := db.ExecUpdate(ub); err != nil {
-		return e.Wrap(err, e.Code0602, "01")
+		return e.W(err, ECode060302)
 	}
 
 	return nil
@@ -89,7 +107,7 @@ func SyncQueueSetHash(db *sql.Connection, id int, hash string) (err error) {
 		Set("updated_on", "now()")
 
 	if err := db.ExecUpdate(ub); err != nil {
-		return e.Wrap(err, e.Code060H, "01")
+		return e.W(err, ECode060303)
 	}
 
 	return nil
@@ -106,7 +124,7 @@ func SyncQueueSetItemHashAndStatus(db *sql.Connection, id int,
 		Set("updated_on", "now()")
 
 	if err := db.ExecUpdate(ub); err != nil {
-		return e.Wrap(err, e.Code060H, "01")
+		return e.W(err, ECode060304)
 	}
 
 	return nil
@@ -122,7 +140,7 @@ func SyncQueueSetError(db *sql.Connection, id int, msg string) (err error) {
 		Set("updated_on", "now()")
 
 	if err := db.ExecUpdate(ub); err != nil {
-		return e.Wrap(err, e.Code060E, "01")
+		return e.W(err, ECode060305)
 	}
 
 	return nil
@@ -140,7 +158,7 @@ func SyncQueueSetDelete(db *sql.Connection, id int, delete bool) (err error) {
 	}
 
 	if err := db.ExecUpdate(ub); err != nil {
-		return e.Wrap(err, e.Code060I, "01")
+		return e.W(err, ECode060306)
 	}
 
 	return nil
@@ -161,7 +179,7 @@ func SyncQueueSetDeleteByServiceItemTypeAndItemID(db *sql.Connection, itemID int
 	}
 
 	if err := db.ExecUpdate(ub); err != nil {
-		return e.Wrap(err, e.Code0603, "01")
+		return e.W(err, ECode060307)
 	}
 
 	return nil
@@ -212,13 +230,13 @@ func SyncQueueGet(db *sql.Connection,
 
 	stmt, bindList, err := sb.ToSql()
 	if err != nil {
-		return nil, 0, e.Wrap(err, e.Code0604, "01")
+		return nil, 0, e.W(err, ECode060308)
 	}
 
 	if p.FlagCount {
 		row := db.QueryRow(strings.Replace(stmt, "{fields}", "count(*)", 1), bindList...)
 		if err := row.Scan(&count); err != nil {
-			return nil, 0, e.Wrap(err, e.Code0604, "02",
+			return nil, 0, e.W(err, ECode060309,
 				fmt.Sprintf("SyncQueueGet.2 | stmt: %s, bindList: %+v",
 					stmt, bindList))
 		}
@@ -253,7 +271,7 @@ func SyncQueueGet(db *sql.Connection,
 	stmt = strings.Replace(stmt, "{fields}", fields, 1)
 	rows, err := db.Query(stmt, bindList...)
 	if err != nil {
-		return nil, 0, e.Wrap(err, e.Code0604, "03")
+		return nil, 0, e.W(err, ECode06030A)
 	}
 	defer rows.Close()
 
@@ -263,12 +281,12 @@ func SyncQueueGet(db *sql.Connection,
 			&sq.Status, &sq.Retries, &sq.Service, &sq.ForDelete,
 			&sq.ItemType, &sq.ItemID, &sq.ItemHash,
 			&sq.CreatedOn, &sq.UpdatedOn); err != nil {
-			return nil, 0, e.Wrap(err, e.Code0604, "04")
+			return nil, 0, e.W(err, ECode06030B)
 		}
 
 		if p.DataHandler != nil {
 			if err := p.DataHandler(sq); err != nil {
-				return nil, 0, e.Wrap(err, e.Code0604, "05")
+				return nil, 0, e.W(err, ECode06030C)
 			}
 		} else {
 			sqList = append(sqList, sq)
@@ -304,11 +322,11 @@ func SyncQueueGetByItemIDTypeAndService(db *sql.Connection, itemID int,
 
 	sqList, _, err := SyncQueueGet(db, p)
 	if err != nil {
-		return nil, e.Wrap(err, e.Code0605, "01")
+		return nil, e.W(err, ECode06030D)
 	}
 
 	if len(sqList) == 0 {
-		return nil, e.New(e.Code0605, "02", "no items found")
+		return nil, e.N(ECode06030E, "no items found")
 	}
 
 	return sqList[0], nil
@@ -318,7 +336,7 @@ func SyncQueueGetByItemIDTypeAndService(db *sql.Connection, itemID int,
 func SyncQueueGetItemIDsByServiceAndItemType(db *sql.Connection, limit, offset int,
 	status []string, itemType, service string) (idList []int, count int, err error) {
 	if len(service) == 0 {
-		return nil, 0, e.Wrap(fmt.Errorf("service cannot be blank"), e.Code0606, "01")
+		return nil, 0, e.N(ECode06030F, "service cannot be blank")
 	}
 
 	serviceList := []string{service}
@@ -340,14 +358,14 @@ func SyncQueueGetItemIDsByServiceAndItemType(db *sql.Connection, limit, offset i
 	stmt = strings.Replace(stmt, "{fields}", fields, 1)
 	rows, err := db.Query(stmt, bindList...)
 	if err != nil {
-		return nil, 0, e.Wrap(err, e.Code0606, "02")
+		return nil, 0, e.W(err, ECode06030G)
 	}
 	defer rows.Close()
 
 	for rows.Next() {
 		var id int
 		if err := rows.Scan(&id); err != nil {
-			return nil, 0, e.Wrap(err, e.Code0606, "03")
+			return nil, 0, e.W(err, ECode06030H)
 		}
 
 		idList = append(idList, id)

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -7,12 +7,18 @@ import (
 	"github.com/Skyrin/go-lib/sync/sqlmodel"
 )
 
+const (
+	ECode060201 = e.Code0602 + "01"
+	ECode060202 = e.Code0602 + "02"
+	ECode060203 = e.Code0602 + "03"
+)
+
 // SyncUpsert performs the DB operation to upsert a record in the sync_queue
 func SyncUpsert(db *sql.Connection, itemID int, input []*model.SyncQueue) (err error) {
 	// Start Tx
 	tx, err := db.BeginReturnDB()
 	if err != nil {
-		return e.Wrap(err, e.Code060D, "01")
+		return e.W(err, ECode060201)
 	}
 	defer db.RollbackIfInTxn()
 
@@ -20,13 +26,13 @@ func SyncUpsert(db *sql.Connection, itemID int, input []*model.SyncQueue) (err e
 		// Save to the sync_queue table for each service
 		_, err = sqlmodel.Upsert(tx, i)
 		if err != nil {
-			return e.Wrap(err, e.Code060D, "02")
+			return e.W(err, ECode060202)
 		}
 	}
 
 	// Commit
 	if err := tx.Commit(); err != nil {
-		return e.Wrap(err, e.Code060D, "03")
+		return e.W(err, ECode060203)
 	}
 
 	return nil


### PR DESCRIPTION
 - package e.codes now defines base codes per file
   (was previously per func)
 - individual files hold all error constants used within that file